### PR TITLE
fix(deps): bump quinn-proto 0.11.14->0.11.15 (RUSTSEC-2026-0185) + gate cargo audit on PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Root Cause

Daily Health Check (`daily-health.yml`) cargo audit flagged **RUSTSEC-2026-0185** (high severity) in `quinn-proto 0.11.14`. The advisory was not present in `ci.yml`'s ignore list and the version in `Cargo.lock` was still 0.11.14.

## Fix

Bumped `quinn-proto` from `0.11.14` to `0.11.15` via:

```
cargo update -p quinn-proto --precise 0.11.15
```

`Cargo.lock`-only change — no `Cargo.toml` modifications required. The version boundary is satisfied by the existing `quinn` dependency range.

## Reciprocal Guard

`ci.yml` already contains an `audit` job (lines 293-322) that runs `cargo audit` with the same `--ignore` list on every push and PR:

```
--ignore RUSTSEC-2023-0071
--ignore RUSTSEC-2025-0134
--ignore RUSTSEC-2025-0144
--ignore RUSTSEC-2026-0097
```

`RUSTSEC-2026-0185` is **not** added to any ignore list in this PR — the fix is real (version bump), not a suppression.

## What Fake-Green Was Removed

None introduced here. The daily health check was already fail-closed; this PR eliminates the actual vulnerability so the check passes for real.

## Local Verification Output

```
$ cargo update -p quinn-proto --precise 0.11.15
    Updating crates.io index
    Updating quinn-proto v0.11.14 -> v0.11.15

$ cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0134 --ignore RUSTSEC-2025-0144 --ignore RUSTSEC-2026-0097
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1139 security advisories (from /home/claude/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (404 crate dependencies)
EXIT_CODE=0
```

Zero vulnerabilities reported. `cargo audit` exits 0.

Generated with Claude Code