### PR TITLE
security: bump quinn-proto for RUSTSEC-2026-0185 (CVSS 7.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Advisory

`quinn-proto 0.11.14` — **remote memory exhaustion** from unbounded out-of-order stream reassembly. [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185), severity **7.5**, published 2026-06-22.

Also bumps, where present:
- [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) `rustls-webpki` — reachable panic parsing CRLs, *before* the CRL's signature is verified
- [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) `crossbeam-epoch` — invalid pointer dereference
- [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) `anyhow` — unsoundness in `Error::downcast_mut()`

## Scope

Lockfile-only. No manifest or API changes.

## Why now

This repo's Daily Health Check has been red on every one of its last 30 runs because `cargo audit` correctly refuses to pass. That red was load-bearing.

Generated with Claude Code